### PR TITLE
Pass Content-Type along to request

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -49,6 +49,8 @@ module Rack
         else
           raise "method not supported: #{m}"
         end
+        
+        req.content_type = rackreq.content_type unless rackreq.content_type.nil?
 
         body = ''
         res = http.request(req) do |res|


### PR DESCRIPTION
Was having some problems using this gem b/c of issues with a `content-type: application/json`. This one line solved my problem.
