### PR TITLE
Send original Content-Type with proxied request, fixed exception when determining Content-Length

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -52,7 +52,8 @@ module Rack
           else
             req.content_length = rackreq.body.size
           end
-          
+
+          req.content_type = rackreq.content_type unless rackreq.content_type.nil?
           req.body_stream = rackreq.body
         else
           raise "method not supported: #{m}"


### PR DESCRIPTION
Was having an issue with the content type not being sent with the proxied request, this fixes that.

Also, there was an exception when determining content length when rackreq.body was a Rack::Lint::InputWrapper under certain circumstances, also resolved in these commits
