### PR TITLE
Preserve port, and delete left-over HOST header if necessary

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -23,7 +23,12 @@ module Rack
           headers[$1] = value
         end
       }
-      headers['HOST'] = uri.host if all_opts[:preserve_host]
+      if all_opts[:preserve_host]
+        headers['HOST'] = uri.host
+        headers['HOST'] << ":#{uri.port}" if uri.port != uri.default_port
+      else
+        headers.delete 'HOST'
+      end
  
       session = Net::HTTP.new(uri.host, uri.port)
       session.read_timeout=all_opts[:timeout] if all_opts[:timeout]


### PR DESCRIPTION
The left-over HOST parameter essentially broke the :preserve_host
feature for me, making it behave as if it was always true.

I'm new to Webmock and cannot figure out a way to add specs for this.
