### PR TITLE
Proxying only works the first time

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -152,7 +152,7 @@ module Rack
     end
 
     def get_uri(path,env)
-      _url=(url.respond_to?(:call) ? url.call(env) : url)
+      _url=(url.respond_to?(:call) ? url.call(env) : url.clone)
       if _url =~/\$\d/
         match_path(path).to_a.each_with_index { |m, i| _url.gsub!("$#{i.to_s}", m) }
         URI(_url)


### PR DESCRIPTION
For me, only the first request worked because apparently the regexp matcher mutates the underlying url variable.  Cloning it fixed the problem.
