### PR TITLE
Add support for X-Forwarded-Host header

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -6,7 +6,7 @@ module Rack
     def initialize(app = nil, &b)
       @app = app || lambda {|env| [404, [], []] }
       @matchers = []
-      @global_options = {:preserve_host => true, :matching => :all, :verify_ssl => true}
+      @global_options = {:preserve_host => true, :x_forwarded_host => true, :matching => :all, :verify_ssl => true}
       instance_eval &b if block_given?
     end
 

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -56,6 +56,12 @@ describe Rack::ReverseProxy do
       a_request(:get, 'http://example.com/test/stuff').with(:headers => {"Host" => "example.com"}).should have_been_made
     end
 
+    it "should set the X-Forwarded-Host header to the proxying host by default" do
+      stub_request(:any, 'example.com/test/stuff')
+      get '/test/stuff'
+      a_request(:get, 'http://example.com/test/stuff').with(:headers => {'X-Forwarded-Host' => 'example.org'}).should have_been_made
+    end
+
     describe "with preserve host turned off" do
       def app
         Rack::ReverseProxy.new(dummy_app) do
@@ -71,18 +77,19 @@ describe Rack::ReverseProxy do
       end
     end
 
-    describe "with x_forwarded_host turned on" do
+    describe "with x_forwarded_host turned off" do
       def app
         Rack::ReverseProxy.new(dummy_app) do
-          reverse_proxy_options :x_forwarded_host => true
+          reverse_proxy_options :x_forwarded_host => false
           reverse_proxy '/test', 'http://example.com/'
         end
       end
 
-      it "should optionally set the X-Forwarded-Host header to the proxying host" do
+      it "should not set the X-Forwarded-Host header to the proxying host" do
         stub_request(:any, 'example.com/test/stuff')
         get '/test/stuff'
-        a_request(:get, 'http://example.com/test/stuff').with(:headers => {'X-Forwarded-Host' => 'example.org'}).should have_been_made
+        a_request(:get, 'http://example.com/test/stuff').with(:headers => {'X-Forwarded-Host' => 'example.org'}).should_not have_been_made
+        a_request(:get, 'http://example.com/test/stuff').should have_been_made
       end
     end
 


### PR DESCRIPTION
This makes it easier for sites like WordPress to be reverse proxied.
