### PR TITLE
Added optional debug logging during proxy operations via :debug option

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -6,7 +6,7 @@ module Rack
     def initialize(app = nil, &b)
       @app = app || lambda {|env| [404, [], []] }
       @matchers = []
-      @global_options = {:preserve_host => true, :matching => :all, :verify_ssl => true}
+      @global_options = {:preserve_host => true, :matching => :all, :verify_ssl => true, :debug => false}
       instance_eval &b if block_given?
     end
 
@@ -24,7 +24,8 @@ module Rack
         end
       }
       headers['HOST'] = uri.host if all_opts[:preserve_host]
- 
+      puts "Proxying #{rackreq.url} => #{uri} (Headers: #{headers.inspect})" if all_opts[:debug]
+
       session = Net::HTTP.new(uri.host, uri.port)
       session.read_timeout=all_opts[:timeout] if all_opts[:timeout]
 

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -84,6 +84,20 @@ describe Rack::ReverseProxy do
         last_response.body.should == "secured content"
       end
     end
+    
+    describe "with debug turned on" do
+      def app
+        @app ||= Rack::ReverseProxy.new(dummy_app) do
+          reverse_proxy '/test', 'http://example.com/', {:debug => true}
+        end
+      end
+
+      it "should print debugging information" do
+        stub_request(:any, 'example.com/test/stuff')
+        app.should_receive(:puts).with("Proxying http://example.org/test/stuff => http://example.com/test/stuff (Headers: {\"HOST\"=>\"example.com\", \"COOKIE\"=>\"\", \"X-Forwarded-Host\"=>\"example.org\"})")
+        get '/test/stuff'
+      end
+    end
 
     describe "with ambiguous routes and all matching" do
       def app


### PR DESCRIPTION
Patch adds a :debug option for enabling an informational debug message during proxy
