### PR TITLE
Replace all instances of '_' with '-' in header name before proxying.

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -20,7 +20,8 @@ module Rack
       headers = Rack::Utils::HeaderHash.new
       env.each { |key, value|
         if key =~ /HTTP_(.*)/
-          headers[$1] = value
+          header = $1.gsub('_', '-')
+          headers[header] = value
         end
       }
       headers['HOST'] = uri.host if all_opts[:preserve_host]


### PR DESCRIPTION
This is probably the least general of the patches I've sent over. Basically I am using the rack-reverse-proxy to funnel traffic from a Heroku Bamboo application to a Cedar application. Because of the way Heroku works with HTTP headers, I needed to replace the underscores with hyphens before passing the traffic back to the next Heroku app. I am happy to wrap this into an option (not really sure what to call it?) and add some tests if there's interest in merging it. Let me know.
