### PR TITLE
Headers work with nginx

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -20,7 +20,7 @@ module Rack
       headers = Rack::Utils::HeaderHash.new
       env.each { |key, value|
         if key =~ /HTTP_(.*)/
-          headers[$1] = value
+          headers[$1.gsub("_", "-")] = value
         end
       }
       headers['HOST'] = uri.host if all_opts[:preserve_host]


### PR DESCRIPTION
This fixes a big problem with nginx. nginx does not send some headers if they have an underscore in them. Since this is a Rack middleware, all headers will be converted into HTTP_FOO_BAR. The original header may have been Foo-Bar or Foo_Bar. We may never know. Actually is a very annoying problem with rack because you can't access the original headers. So, we simply replace `_`'s with `-` and everything is cool. Most likely the `_`'s were `-`'s in the first place.
