### PR TITLE
Return proxied headers as strings, rather than arrays.

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -19,7 +19,7 @@ module Rack
       all_opts = @global_options.dup.merge(matcher.options)
       headers = Rack::Utils::HeaderHash.new
       env.each { |key, value|
-        if key =~ /HTTP_(.*)/
+        if key =~ /HTTP_(.*)/ and not value.nil? and not value.empty?
           headers[$1] = value
         end
       }
@@ -37,6 +37,7 @@ module Rack
         session.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end
       session.start { |http|
+        puts "Reverse Request Headers: #{headers.inspect}"
         m = rackreq.request_method
         case m
         when "GET", "HEAD", "DELETE", "OPTIONS", "TRACE"

--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -88,7 +88,8 @@ module Rack
     end
 
     def create_response_headers http_response
-      response_headers = Rack::Utils::HeaderHash.new(http_response.to_hash)
+      headers = Hash[http_response.to_hash.collect{ |k,v| [k,v.first]}]
+      response_headers = Rack::Utils::HeaderHash.new(headers)
       # handled by Rack
       response_headers.delete('status')
       # TODO: figure out how to handle chunked responses

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -26,6 +26,12 @@ describe Rack::ReverseProxy do
       last_response.should be_ok
     end
 
+    it "should return headers from proxied app as strings" do
+      stub_request(:get, 'http://example.com/test').to_return({:body => "Proxied App", :headers => { 'Proxied-Header' => 'TestValue' } })
+      get '/test'
+      last_response.headers['Proxied-Header'].should == "TestValue"
+    end
+
     it "should proxy requests when a pattern is matched" do
       stub_request(:get, 'http://example.com/test').to_return({:body => "Proxied App"})
       get '/test'


### PR DESCRIPTION
This is a fix for issue 24.  https://github.com/jaswope/rack-reverse-proxy/issues/24

Rack::Cache breaks upstream from Rack::ReverseProxy because it tries to treat the Cache-Control header as a string.
