### PR TITLE
Added a feature to optionally post process the body of a proxied response.

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -19,7 +19,7 @@ module Rack
       all_opts = @global_options.dup.merge(matcher.options)
       headers = Rack::Utils::HeaderHash.new
       env.each { |key, value|
-        if key =~ /HTTP_(.*)/
+        if key =~ /HTTP_(.*)/ and not value.nil? and not value.empty?
           headers[$1] = value
         end
       }
@@ -37,6 +37,7 @@ module Rack
         session.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end
       session.start { |http|
+        puts "Reverse Request Headers: #{headers.inspect}"
         m = rackreq.request_method
         case m
         when "GET", "HEAD", "DELETE", "OPTIONS", "TRACE"

--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -88,7 +88,8 @@ module Rack
     end
 
     def create_response_headers http_response
-      response_headers = Rack::Utils::HeaderHash.new(http_response.to_hash)
+      headers = Hash[http_response.to_hash.collect{ |k,v| [k,v.first]}]
+      response_headers = Rack::Utils::HeaderHash.new(headers)
       # handled by Rack
       response_headers.delete('status')
       # TODO: figure out how to handle chunked responses

--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -68,7 +68,7 @@ module Rack
           end
         end
 
-        body = matcher.post_process_body(body)
+        body = matcher.post_process_body(body, res)
 
         [res.code, create_response_headers(res), [body]]
       }
@@ -167,8 +167,8 @@ module Rack
       end
     end
 
-    def post_process_body(body)
-      @body_modifier.nil? ? body : @body_modifier.call(body)
+    def post_process_body(body, res)
+      @body_modifier.nil? ? body : @body_modifier.call(body, res)
     end
 
     def to_s

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -26,6 +26,12 @@ describe Rack::ReverseProxy do
       last_response.should be_ok
     end
 
+    it "should return headers from proxied app as strings" do
+      stub_request(:get, 'http://example.com/test').to_return({:body => "Proxied App", :headers => { 'Proxied-Header' => 'TestValue' } })
+      get '/test'
+      last_response.headers['Proxied-Header'].should == "TestValue"
+    end
+
     it "should proxy requests when a pattern is matched" do
       stub_request(:get, 'http://example.com/test').to_return({:body => "Proxied App"})
       get '/test'


### PR DESCRIPTION
Allows user to easily post-process the http body before sending it back through the Rack pipeline. This is implemented by allowing a block to be passed to the reverse_proxy statement. The block will be called for each request after the body is received from the origin server. The return value of the block is passed back up the stack. We don't allow changing any of the headers or status at this stage. 

_This function can be used to replace hrefs in the body or to filter content, etc…_

Example:

```
reverse_proxy '/test', 'http://example.com' do |body|
  # replace any urls in the body that reference example.com with the new path.
  body.gsub 'http://example.com/', '/test/'
end
```
