### PR TITLE
Proxy original http headers along with the request

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rack-reverse-proxy (0.4.1)
+    rack-reverse-proxy (0.4.4)
       rack (>= 1.0.0)
 
 GEM
@@ -22,7 +22,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.0.15)
+  bundler (~> 1.2.3)
   rack-reverse-proxy!
   rack-test (~> 0.5.7)
   rake (~> 0.8.7)

--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -20,9 +20,10 @@ module Rack
       headers = Rack::Utils::HeaderHash.new
       env.each { |key, value|
         if key =~ /HTTP_(.*)/
-          headers[$1] = value
+          headers[$1.gsub('_', '-')] = value
         end
       }
+    debugger
       headers['HOST'] = uri.host if all_opts[:preserve_host]
       headers['X-Forwarded-Host'] = rackreq.host if all_opts[:x_forwarded_host]
 

--- a/rack-reverse-proxy.gemspec
+++ b/rack-reverse-proxy.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   ]
 
   s.add_development_dependency "rspec", "~> 1.3.2"
-  s.add_development_dependency "bundler", "~> 1.0.15"
+  s.add_development_dependency "bundler", "~> 1.2.3"
   s.add_development_dependency "rake", "~> 0.8.7"
   s.add_development_dependency "rack-test", "~> 0.5.7"
   s.add_development_dependency "webmock", "~> 1.5.0"

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -62,6 +62,13 @@ describe Rack::ReverseProxy do
       a_request(:get, 'http://example.com/test/stuff').with(:headers => {'X-Forwarded-Host' => 'example.org'}).should have_been_made
     end
 
+    it "should pass the HTTP_USER_AGENT to the proxied server" do
+      stub_request(:any, 'example.com/test/stuff')
+      get '/test/stuff', nil, { 'HTTP_USER_AGENT' => 'test agent' }
+      a_request(:get, 'http://example.com/test/stuff').with(:headers => {'User-Agent' => 'test agent'}).should have_been_made
+    end
+
+
     describe "with preserve host turned off" do
       def app
         Rack::ReverseProxy.new(dummy_app) do


### PR DESCRIPTION
Fixed an issue that was preventing the original request headers (i.e. HTTP_USER_AGENT) from being included in the proxy request.    Net::HTTP is expecting these headers to be specified as USER-AGENT, not USER_AGENT.

Updated tests included..
