### PR TITLE
set Content-Length correctly

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -67,7 +67,7 @@ module Rack
           end
         end
 
-        [res.code, create_response_headers(res), [body]]
+        [res.code, create_response_headers(res, body), [body]]
       }
     end
 
@@ -87,13 +87,14 @@ module Rack
       end
     end
 
-    def create_response_headers http_response
+    def create_response_headers(http_response, body)
       response_headers = Rack::Utils::HeaderHash.new(http_response.to_hash)
       # handled by Rack
       response_headers.delete('status')
       # TODO: figure out how to handle chunked responses
       response_headers.delete('transfer-encoding')
       # TODO: Verify Content Length, and required Rack headers
+      response_headers['Content-Length'] = body.bytesize.to_s
       response_headers
     end
 


### PR DESCRIPTION
hello,

I had the problem that the `Content-Length` was set incorrectly with ruby 2.
it was set to the size before gzip decompression. I created a fix which always set the actual length of the response body.

I would be happy if you can give me feedback if this fix is okay or if you can reproduce the bug.
or when you have a better solution.

for now I will embed my fork into my gemfile so that the gem works again with the newest ruby version.

thanks!
