### PR TITLE
Add option to only proxy requests sent over https

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ rdoc
 pkg
 
 ## PROJECT::SPECIFIC
+
+.ruby-gemset

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rack-reverse-proxy (0.4.1)
+    rack-reverse-proxy (0.4.4)
       rack (>= 1.0.0)
 
 GEM

--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -6,7 +6,7 @@ module Rack
     def initialize(app = nil, &b)
       @app = app || lambda {|env| [404, [], []] }
       @matchers = []
-      @global_options = {:preserve_host => true, :x_forwarded_host => true, :matching => :all, :verify_ssl => true}
+      @global_options = {:preserve_host => true, :x_forwarded_host => true, :matching => :all, :verify_ssl => true, :only_proxy_ssl => false}
       instance_eval &b if block_given?
     end
 
@@ -28,6 +28,8 @@ module Rack
 
       session = Net::HTTP.new(uri.host, uri.port)
       session.read_timeout=all_opts[:timeout] if all_opts[:timeout]
+
+      return @app.call(env) if all_opts[:only_proxy_ssl] && rackreq.scheme != 'https'
 
       session.use_ssl = (uri.scheme == 'https')
       if uri.scheme == 'https' && all_opts[:verify_ssl]

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -219,6 +219,48 @@ describe Rack::ReverseProxy do
         end
       end
     end
+
+    describe "with only_proxy_ssl" do
+      before :each do
+        stub_request(:get, 'https://example.com/test/').to_return({:body => "Proxied App"})
+      end
+
+      describe "turned on" do
+        def app
+          Rack::ReverseProxy.new(dummy_app) do
+            reverse_proxy '/test', 'https://example.com', {:only_proxy_ssl => true}
+          end
+        end
+
+        it "should not proxy a request sent over HTTP" do
+          get 'https://localhost/test/'
+          last_response.body.should == "Proxied App"
+        end
+
+        it "should proxy a request sent over HTTPS" do
+          get 'http://localhost/test/'
+          last_response.body.should == "Dummy App"
+        end
+      end
+
+      describe "turned off" do
+        def app
+          Rack::ReverseProxy.new(dummy_app) do
+            reverse_proxy '/test', 'https://example.com', {:only_proxy_ssl => false}
+          end
+        end
+
+        it "should proxy a request sent over HTTP" do
+          get 'https://localhost/test/'
+          last_response.body.should == "Proxied App"
+        end
+
+        it "should proxy a request sent over HTTPS" do
+          get 'http://localhost/test/'
+          last_response.body.should == "Proxied App"
+        end
+      end
+    end
   end
 
   describe "as a rack app" do


### PR DESCRIPTION
I had the need to only reverse proxy requests sent over https.  Any request sent over HTTP I needed to redirect to HTTPS.

Let me know if you think there is a better way to do this.
