### PR TITLE
Rewind request body stream before trying to get its size

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -47,6 +47,7 @@ module Rack
           req.basic_auth all_opts[:username], all_opts[:password] if all_opts[:username] and all_opts[:password]
 
           if rackreq.body.respond_to?(:read) && rackreq.body.respond_to?(:rewind)
+            rackreq.body.rewind
             body = rackreq.body.read
             req.content_length = body.size
             rackreq.body.rewind


### PR DESCRIPTION
In some cases there might a glitch that AJAX requests with body payload are not proxies properly. They fully delivered to localhost, but then they got Content-Length: 0 and payload doesn't send further to remote host. I've found that it was because we try to get size of body when it's already has been read (I don't know why).

This simple patch fixes that issue.
