### PR TITLE
Ensure Content-Length header is set properly

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -65,6 +65,8 @@ module Rack
           res.read_body do |segment|
             body << segment
           end
+          # ensure content length header is correct
+          res.content_length = body.bytesize
         end
 
         [res.code, create_response_headers(res), [body]]
@@ -93,7 +95,7 @@ module Rack
       response_headers.delete('status')
       # TODO: figure out how to handle chunked responses
       response_headers.delete('transfer-encoding')
-      # TODO: Verify Content Length, and required Rack headers
+      # TODO: Verify required Rack headers
       response_headers
     end
 

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -50,6 +50,13 @@ describe Rack::ReverseProxy do
       last_response.headers['transfer-encoding'].should == nil
     end
 
+    it "the response header should include content-length" do
+      body = 'this is the test body'
+      stub_request(:any, 'example.com/test/stuff').to_return(:body => body, :headers => {'Content-Length' => '10'})
+      get '/test/stuff'
+      last_response.headers['Content-Length'].should == body.length.to_s
+    end
+
     it "should set the Host header" do
       stub_request(:any, 'example.com/test/stuff')
       get '/test/stuff'


### PR DESCRIPTION
Seeing some issues with `Content-Length` being corrupted, this ensures it matches body length as delivered.
