### PR TITLE
Un-underscore header names provided by Rack

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -20,7 +20,7 @@ module Rack
       headers = Rack::Utils::HeaderHash.new
       env.each { |key, value|
         if key =~ /HTTP_(.*)/
-          headers[$1] = value
+          headers[$1.gsub('_', '-')] = value if value
         end
       }
       headers['HOST'] = uri.host if all_opts[:preserve_host]


### PR DESCRIPTION
This fixes two problems:
- This will now properly convert underscored header names to their dashed equivalent. Custom headers like `Content-MD5` turns into `HTTP_CONTENT_MD5` in Rack, so converting back from `CONTENT_MD5` to `CONTENT-MD5` is required. 
- Sometimes Rack's header values are `nil`. The one I've encountered so far using Rails in development is `Origin`. This will only set the header if the value is non-`nil`.
