### PR TITLE
[FIX] Capitalize headers correctly

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -12,7 +12,7 @@ module Rack
       @app = app || lambda {|env| [404, [], []] }
       @matchers = []
       @global_options = {:preserve_host => true, :x_forwarded_host => true, :matching => :all, :replace_response_host => false}
-      instance_eval &b if block_given?
+      instance_eval(&b) if block_given?
     end
 
     def call(env)

--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -74,14 +74,14 @@ module Rack
       target_response.use_ssl = "https" == uri.scheme
 
       # Let rack set the transfer-encoding header
-      response_headers = target_response.headers
-      response_headers.delete('transfer-encoding')
+      response_headers = format_headers(target_response.headers)
+      response_headers.delete('Transfer-Encoding')
 
       # Replace the location header with the proxy domain
-      if response_headers['location'] && options[:replace_response_host]
-        response_location = URI(response_headers['location'][0])
+      if response_headers['Location'] && options[:replace_response_host]
+        response_location = URI(response_headers['Location'][0])
         response_location.host = source_request.host
-        response_headers['location'] = response_location.to_s
+        response_headers['Location'] = response_location.to_s
       end
 
       [target_response.status, response_headers, target_response.body]
@@ -128,6 +128,13 @@ module Rack
     def reverse_proxy(matcher, url=nil, opts={})
       raise GenericProxyURI.new(url) if matcher.is_a?(String) && url.is_a?(String) && URI(url).class == URI::Generic
       @matchers << ReverseProxyMatcher.new(matcher,url,opts)
+    end
+
+    def format_headers(headers)
+      headers.each_with_object({}).each do |(key, val), acc|
+        formated_key = key.split('-').map(&:capitalize).join('-')
+        acc[formated_key] = Array(val)
+      end
     end
   end
 end

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Rack::ReverseProxy do
         Rack::ReverseProxy.new(dummy_app) do
           reverse_proxy_options :matching => :all
           reverse_proxy '/test', 'http://example.com/'
-          reverse_proxy /^\/test/, 'http://example.com/'
+          reverse_proxy(/^\/test/, 'http://example.com/')
         end
       end
 
@@ -128,7 +128,7 @@ RSpec.describe Rack::ReverseProxy do
         Rack::ReverseProxy.new(dummy_app) do
           reverse_proxy_options :matching => :first
           reverse_proxy '/test', 'http://example1.com/'
-          reverse_proxy /^\/test/, 'http://example2.com/'
+          reverse_proxy(/^\/test/, 'http://example2.com/')
         end
       end
 

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe Rack::ReverseProxy do
       a_request(:get, 'http://example.com/test/stuff').with(:headers => {'X-Forwarded-Host' => 'example.org'}).should have_been_made
     end
 
+    it 'should format the headers correctly to avoid duplicates' do
+      stub_request(:get, 'http://example.com/2test').to_return({:status => 301, :headers => {:status => '301 Moved Permanently'}})
+
+      get '/2test'
+
+      headers = last_response.headers.to_hash
+      headers['Status'].should == "301 Moved Permanently"
+      headers['status'].should be_nil
+    end
+
     describe "with preserve host turned off" do
       def app
         Rack::ReverseProxy.new(dummy_app) do


### PR DESCRIPTION
This prevents duplicate headers downstream with other proxies.  I was getting two status headers being returned. `status` and `Status`.  

This makes rack-reverse-proxy` play nicely with others that expect headers to be capitalized.
