### PR TITLE
[FIX] Don't drop the port of the request 

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -81,6 +81,7 @@ module Rack
       if response_headers['location'] && options[:replace_response_host]
         response_location = URI(response_headers['location'][0])
         response_location.host = source_request.host
+        response_location.port = source_request.port
         response_headers['location'] = response_location.to_s
       end
 

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -107,6 +107,12 @@ RSpec.describe Rack::ReverseProxy do
         # puts last_response.headers.inspect
         last_response.headers['location'].should == "http://example.com/bar"
       end
+
+      it "should keep the port of the location" do
+        stub_request(:get, "http://example.com/test/stuff").to_return(:headers => {"location" => "http://test.com/bar"})
+        get 'http://example.com:3000/test/stuff'
+        last_response.headers['location'].should == "http://example.com:3000/bar"
+      end
     end
 
     describe "with ambiguous routes and all matching" do


### PR DESCRIPTION
This fixes a bug where the source request's port was being dropped when
replacing the response's location header.
