### PR TITLE
Omit port in Host header for default ports

### DIFF
--- a/lib/rack/reverse_proxy.rb
+++ b/lib/rack/reverse_proxy.rb
@@ -46,7 +46,11 @@ module Rack
       target_request_headers = extract_http_request_headers(source_request.env)
 
       if options[:preserve_host]
-        target_request_headers['HOST'] = "#{uri.host}:#{uri.port}"
+        if uri.port == uri.default_port
+          target_request_headers['HOST'] = uri.host
+        else
+          target_request_headers['HOST'] = "#{uri.host}:#{uri.port}"
+        end
       end
 
       if options[:x_forwarded_host]

--- a/spec/rack/reverse_proxy_spec.rb
+++ b/spec/rack/reverse_proxy_spec.rb
@@ -37,16 +37,30 @@ RSpec.describe Rack::ReverseProxy do
       last_response.body.should == "Proxied App2"
     end
 
-    it "should set the Host header" do
+    it "should set the Host header w/o default port" do
       stub_request(:any, 'example.com/test/stuff')
       get '/test/stuff'
-      a_request(:get, 'http://example.com/test/stuff').with(:headers => {"Host" => "example.com:80"}).should have_been_made
+      a_request(:get, 'http://example.com/test/stuff').with(:headers => {"Host" => "example.com"}).should have_been_made
     end
 
     it "should set the X-Forwarded-Host header to the proxying host by default" do
       stub_request(:any, 'example.com/test/stuff')
       get '/test/stuff'
       a_request(:get, 'http://example.com/test/stuff').with(:headers => {'X-Forwarded-Host' => 'example.org'}).should have_been_made
+    end
+
+    describe "with non-default port" do
+      def app
+        Rack::ReverseProxy.new(dummy_app) do
+          reverse_proxy '/test', 'http://example.com:8080/'
+        end
+      end
+
+      it "should set the Host header including non-default port" do
+        stub_request(:any, 'example.com:8080/test/stuff')
+        get '/test/stuff'
+        a_request(:get, 'http://example.com:8080/test/stuff').with(:headers => {"Host" => "example.com:8080"}).should have_been_made
+      end
     end
 
     describe "with preserve host turned off" do
@@ -166,6 +180,25 @@ RSpec.describe Rack::ReverseProxy do
         last_response.body.should == "Proxied Secure App"
       end
 
+      it "should set the Host header w/o default port" do
+        stub_request(:any, 'https://example.com/test/stuff')
+        get '/test/stuff'
+        a_request(:get, 'https://example.com/test/stuff').with(:headers => {"Host" => "example.com"}).should have_been_made
+      end
+    end
+
+    describe "with a https route on non-default port" do
+      def app
+        Rack::ReverseProxy.new(dummy_app) do
+          reverse_proxy '/test', 'https://example.com:8443'
+        end
+      end
+
+      it "should set the Host header including non-default port" do
+        stub_request(:any, 'https://example.com:8443/test/stuff')
+        get '/test/stuff'
+        a_request(:get, 'https://example.com:8443/test/stuff').with(:headers => {"Host" => "example.com:8443"}).should have_been_made
+      end
     end
 
     describe "with a route as a string" do


### PR DESCRIPTION
Hi,

while using `rack-reverse-proxy` we discovered that proxying to "Apache Coyote" won't work
if the `Host` header includes the port for _default ports_ (like 80 or 443). E.g.:

```
Host: example.com:80
```

In this PR the default port will be skipped in `Host` header.

Most clients don't set this default port too:
- https://github.com/request/request/issues/515#issue-13221755
- https://github.com/ruby/ruby/blob/d46336e71731aa64d71d4573b2741b7de43ec340/lib/net/http/generic_request.rb#L18

Comments?

Kind regards,
  Peter
