### PR TITLE
Adding MIT license to the gemspec.

### DIFF
--- a/rack-reverse-proxy.gemspec
+++ b/rack-reverse-proxy.gemspec
@@ -1,6 +1,7 @@
 Gem::Specification.new do |s|
   s.name          = 'rack-reverse-proxy'
   s.version       = "0.8.1"
+  s.license       = "MIT"
   s.authors       = ["Jon Swope", "Ian Ehlert", "Roman Ernst"]
   s.description   = 'A Rack based reverse proxy for basic needs.  Useful for testing or in cases where webserver configuration is unavailable.'
   s.email         = ["jaswope@gmail.com", "ehlertij@gmail.com", "rernst@farbenmeer.net"]


### PR DESCRIPTION
I'm working on [VersionEye](https://www.versioneye.com/) and my goal is to build up a license db for RubyGems which is complete. To reduce the manual work I'm doing currently it would be awesome if this gemspec would contain the license information in future. Many Thanks.
